### PR TITLE
Updated template for upcoming Scala IDE v3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
 scala-ide-plugin.g8
 ===================
 
-Giter8 template for Eclipse plugins based on the Scala IDE.
+[Giter8](https://github.com/n8han/giter8) template for Eclipse plugins based on the Scala IDE.
+
+How to create your Scala IDE plug-in in less than 5 minutes
+-----------------------------------------------------------
+
+* Install [giter8](https://github.com/n8han/giter8) (follow the instructions in the linked repository).
+* Add **g8** to your ``$PATH``, and then
+
+```bash
+$ g8 git://github.com/scala-ide/scala-ide-plugin.g8.git
+name [Scala IDE Sample plugin]: My Plugin
+provider [org.example]: my.domain
+pluginName [org.example.plugin]: my.domain.plugin
+className [SampleAction]: MyAction
+providerName [Scala IDE]: Me
+
+Applied scala-ide/scala-ide-plugin.g8 in my-plugin
+```
+
+You should now have a ``my-plugin`` folder containing the following 5 Eclipse plug-ins:
 
 This template produces 5 Eclipse plugins:
 
@@ -14,16 +33,7 @@ This template produces 5 Eclipse plugins:
 The projects can readily be imported inside Eclipse. Additionally, you have maven `pom` files
 based on Tycho, enabling command line builds.
 
-## Note:
+## Note
 
-By default, the maven build is performed against the latest stable versions (Scala IDE 2.0 and Scala 2.9).
-The available profiles are:
-
-* `scala-ide-2.0-scala-2.9` (default)
-* `scala-ide-2.0.x-scala-2.9`
-* `scala-ide-master-scala-2.9`
-* `scala-ide-master-scala-trunk`
-
-Run maven like this:
-
-    mvn -P scala-ide-master-scala-trunk clean install
+After creating the project's scafolding, you will have to update the *scm configuration* in your project's 
+POM **before** building.

--- a/src/main/g8/$pluginName$/META-INF/MANIFEST.MF
+++ b/src/main/g8/$pluginName$/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle:
  org.eclipse.core.runtime,
  org.eclipse.debug.ui,
  org.eclipse.help,
- org.eclipse.jdt.core;bundle-version="[3.6.0,3.7.10)",
+ org.eclipse.jdt.core,
  org.eclipse.jdt.debug.ui,
  org.eclipse.jdt.junit,
  org.eclipse.jdt.launching,
@@ -23,7 +23,7 @@ Require-Bundle:
  org.eclipse.ui.ide,
  org.scala-ide.scala.library,
  org.scala-ide.scala.compiler,
- org.scala-ide.sdt.core;bundle-version="[2.0.0, 2.2.0)"
+ org.scala-ide.sdt.core
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse;apply-aspects:=false,

--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -1,9 +1,7 @@
-scala-ide-plugin.g8
-===================
+README
+======
 
-Giger8 template for Eclipse plugins based on the Scala IDE.
-
-This template produces 5 Eclipse plugins:
+This project contains 5 Eclipse plugins:
 
 * the plugin itself
 * the `plugin.tests` fragment
@@ -16,14 +14,22 @@ based on Tycho, enabling command line builds.
 
 ## Note:
 
-By default, the maven build is performed against the latest stable versions (Scala IDE 2.0 and Scala 2.9).
-The available profiles are:
+There are three sets of ready-to-use profiles, for different flavors of Scala and Eclipse. 
 
-* `scala-ide-2.0-scala-2.9` (default)
-* `scala-ide-2.0.x-scala-2.9`
-* `scala-ide-master-scala-2.9`
-* `scala-ide-master-scala-trunk`
+* `indigo` (default)
+    * `stable-scala-ide-scala-2.10-indigo` + `scala-2.10` (default) 
+    * `stable-scala-ide-scala-2.9-indigo` + `scala-2.9`
+* `juno`
+    * `stable-scala-ide-scala-2.10-juno` + `scala-2.10`
+    * `stable-scala-ide-scala-2.9-juno` + `scala-2.9`
+
+By default, the maven build is performed against the latest stable versions (Scala IDE 3.0 
+and Scala 2.10), and it targets Eclipse 3.7 (Indigo).
 
 Run maven like this:
 
-    mvn -P scala-ide-master-scala-trunk clean install
+    mvn -P indigo -P stable-scala-ide-scala-2.10-indigo -P scala-2.10 clean install
+    
+Or, because the above command uses only default profiles, you can shorten it to:
+
+    mvn clean install

--- a/src/main/g8/pom.xml
+++ b/src/main/g8/pom.xml
@@ -22,13 +22,10 @@
   <properties>
     <encoding>UTF-8</encoding>
     <!-- p2 repositories location -->
-    <repo.eclipse.indigo>http://download.eclipse.org/releases/indigo/</repo.eclipse.indigo>
-    <repo.eclipse.juno>http://download.eclipse.org/releases/juno/</repo.eclipse.juno>
-    <repo.ajdt.indigo>http://download.eclipse.org/tools/ajdt/37/dev/update</repo.ajdt.indigo>
     <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
 
     <!-- fixed versions -->
-    <tycho.version>0.15.0</tycho.version>
+    <tycho.version>0.16.0</tycho.version>
     <scala.plugin.version>3.0.2</scala.plugin.version>
 
     <!-- tycho test related -->
@@ -39,45 +36,74 @@
 
     <!-- dependencies repos -->
     <eclipse.codename>indigo</eclipse.codename>
-    <repo.eclipse>\${repo.eclipse.indigo}</repo.eclipse>
-    <repo.ajdt>\${repo.ajdt.indigo}</repo.ajdt>
+    <repo.eclipse>http://download.eclipse.org/releases/indigo/</repo.eclipse>
+    <repo.ajdt>http://download.eclipse.org/tools/ajdt/37/update</repo.ajdt>
+    <weaving.hook.plugin.version>1.0.200.I20120427-0800</weaving.hook.plugin.version>
 
     <!-- some default values, can be overwritten by profiles -->
-    <scala.version>2.9.3-SNAPSHOT</scala.version>
-    <version.suffix>2_09</version.suffix>
-    <scala.version.short>2.9</scala.version.short>
+    <scala.version>2.10.1</scala.version>
+    <version.suffix>2_10</version.suffix>
+    <scala.version.short>2.10</scala.version.short>
     <version.tag>local</version.tag>
-    <repo.scala-ide>\${repo.scala-ide.root}/releases-29/stable/site</repo.scala-ide>
+    <repo.scala-ide>\${repo.scala-ide.root}/sdk/e37/scala210/stable/site</repo.scala-ide>
     <junit.version>4.10</junit.version>
    </properties>
 
   <profiles>
     <profile>
-      <!-- this is the default profile, using the stable builds-->
-      <id>scala-ide-2.0-scala-2.9</id>
+      <!-- this is the default profile, building for Scala 2.10 -->
+      <id>scala-2.10</id>
     </profile>
     <profile>
-      <!-- 2.0.x Scala IDE with Scala 2.9 -->
-      <id>scala-ide-2.0.x-scala-2.9</id>
+      <!-- Building for Scala 2.9 -->
+      <id>scala-2.9</id>
       <properties>
-        <repo.scala-ide>\${repo.scala-ide.root}/nightly-update-2-0-x-29x</repo.scala-ide>
+        <scala.version>2.9.3</scala.version>
+        <version.suffix>2_9</version.suffix>
+        <scala.version.short>2.9</scala.version.short>
+      </properties>
+    </profile>
+
+    <profile>
+      <!-- this is the default profile, building for Eclipse 3.7 (Indigo) -->
+      <id>indigo</id>
+    </profile>
+
+    <profile>
+      <!-- this is the default profile, using the stable Scala IDE release -->
+      <!-- stable Scala IDE for Eclipse Indigo with Scala 2.10 -->
+      <id>stable-scala-ide-scala-2.10-indigo</id>
+    </profile>
+    <profile>
+      <!-- stable Scala IDE for Eclipse Indigo with Scala 2.9 -->
+      <id>stable-scala-ide-scala-2.9-indigo</id>
+      <properties>
+        <repo.scala-ide>\${repo.scala-ide.root}/sdk/e37/scala29/stable/site</repo.scala-ide>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>juno</id>
+      <properties>
+        <eclipse.codename>juno</eclipse.codename>
+        <repo.eclipse>http://download.eclipse.org/releases/juno/</repo.eclipse>
+        <repo.ajdt>http://download.eclipse.org/tools/ajdt/42/update</repo.ajdt>
+        <weaving.hook.plugin.version>1.0.200.v20120524-1707</weaving.hook.plugin.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <!-- stable Scala IDE for Eclipse Juno with Scala 2.10 -->
+      <id>stable-scala-ide-scala-2.10-juno</id>
+      <properties>
+         <repo.scala-ide>\${repo.scala-ide.root}/sdk/e38/scala210/stable/site</repo.scala-ide>
       </properties>
     </profile>
     <profile>
-      <!-- nightly Scala IDE with Scala 2.9 -->
-      <id>scala-ide-master-scala-2.9</id>
+      <!-- stable Scala IDE for Eclipse Juno with Scala 2.9 -->
+      <id>stable-scala-ide-scala-2.9-juno</id>
       <properties>
-        <repo.scala-ide>\${repo.scala-ide.root}/nightly-update-master-29x</repo.scala-ide>
-      </properties>
-    </profile>
-    <profile>
-      <!-- nightly Scala IDE with Scala trunk -->
-      <id>scala-ide-master-scala-trunk</id>
-      <properties>
-        <scala.version>2.10.0-SNAPSHOT</scala.version>
-        <version.suffix>2_10</version.suffix>
-        <scala.version.short>2.10</scala.version.short>
-        <repo.scala-ide>\${repo.scala-ide.root}/nightly-update-master-trunk</repo.scala-ide>
+        <repo.scala-ide>\${repo.scala-ide.root}/sdk/e38/scala29/stable/site</repo.scala-ide>
       </properties>
     </profile>
 
@@ -111,12 +137,58 @@
         </pluginManagement>
       </build>
     </profile>
+    
+    <profile>
+      <!-- This profile should be used when building the plugin for inclusion in the Scala IDE ecosystem. See https://github.com/scala-ide/ecosystem/wiki -->
+      <!-- Using the value of -Drepo.scala-ide, pulls the data needed to set strict version numbers to the manifests for Scala IDE bundles -->
+      <id>set-versions</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.scala-ide</groupId>
+          <artifactId>build-tools_2.9.2</artifactId>
+          <version>0.1.1</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.2.1</version>
+            <executions>
+              <execution>
+                <id>copy.reflect</id>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <classpathScope>compile</classpathScope>
+              <mainClass>org.scalaide.buildtools.UpdateAddonManifests</mainClass>
+              <arguments>
+                <argument>\${repo.scala-ide}</argument>
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <repositories>
+        <repository>
+          <!-- extra repository containing the build package -->
+          <id>typesafe-ide</id>
+          <name>Typesafe IDE repository</name>
+          <url>http://repo.typesafe.com/typesafe/ide-2.9</url>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
   </profiles>
 
   <!-- scm configuration is require to extract the github hash-->
   <scm> 
-    <connection>scm:git://github.com/skyluc/plugin.git</connection> 
-    <url>https://github.com/skyluc/plugin</url> 
+    <connection>scm:[Git URL to your git repository]</connection> 
+    <url>[URL to your project's repository]</url> 
   </scm>
 
   <dependencyManagement>
@@ -188,7 +260,7 @@
               <frameworkExtension>
                 <groupId>p2.osgi.bundle</groupId>
                 <artifactId>org.eclipse.equinox.weaving.hook</artifactId>
-                <version>1.0.200.I20120427-0800</version>
+                <version>\${weaving.hook.plugin.version}</version>
               </frameworkExtension>
             </frameworkExtensions>
             <bundleStartLevel>


### PR DESCRIPTION
## What's New
- Updated project's README and explained how to create a Scala IDE plug-in in 3 simple steps.
- Updated POM used by the generated plug-in
  - Use Tycho 0.16
  - Parametrized indigo and juno builds
  - Updated build profiles for next Scala IDE v3.0 release
  - Added profile for setting strict bundle versions (needed before building plug-in for inclusion in the ecosystem)
- Update README of the generated plug-in to reflect changes in the POM's profile
## Note 

This should be merged only **after** v3.0.0 final is announced.
