### PR TITLE
Updated template for upcoming Scala IDE v3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
 scala-ide-plugin.g8
 ===================
 
-Giter8 template for Eclipse plugins based on the Scala IDE.
+[Giter8](https://github.com/n8han/giter8) template for Eclipse plugins based on the Scala IDE.
+
+How to create your Scala IDE plug-in in less than 5 minutes
+-----------------------------------------------------------
+
+* Install [giter8](https://github.com/n8han/giter8) (follow the instructions in the linked repository).
+* Add **g8** to your ``$PATH``, and then
+
+```bash
+$ g8 git://github.com/scala-ide/scala-ide-plugin.g8.git
+name [Scala IDE Sample plugin]: My Plugin
+provider [org.example]: my.domain
+pluginName [org.example.plugin]: my.domain.plugin
+className [SampleAction]: MyAction
+providerName [Scala IDE]: Me
+
+Applied scala-ide/scala-ide-plugin.g8 in my-plugin
+```
+
+You should now have a ``my-plugin`` folder containing the following 5 Eclipse plug-ins:
 
 This template produces 5 Eclipse plugins:
 
@@ -14,8 +33,7 @@ This template produces 5 Eclipse plugins:
 The projects can readily be imported inside Eclipse. Additionally, you have maven `pom` files
 based on Tycho, enabling command line builds.
 
-## Building:
+## Note
 
-This template uses [plugin-profiles](https://github.com/scala-ide/plugin-profiles) to manage the build. Check its documentation for detailed information. The command to use looks like this:
-
-    mvn -Pscala-2.10.x,eclipse-indigo,scala-ide-stable clean install
+After creating the project's scafolding, you will have to update the *scm configuration* in your project's
+POM **before** building.

--- a/src/main/g8/$pluginName$/META-INF/MANIFEST.MF
+++ b/src/main/g8/$pluginName$/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle:
  org.eclipse.ui.ide,
  org.scala-ide.scala.library,
  org.scala-ide.scala.compiler,
- org.scala-ide.sdt.core;bundle-version="[3.0.0, 4.0.0)"
+ org.scala-ide.sdt.core
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse;apply-aspects:=false,

--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -1,9 +1,7 @@
-scala-ide-plugin.g8
-===================
+README
+======
 
-Giger8 template for Eclipse plugins based on the Scala IDE.
-
-This template produces 5 Eclipse plugins:
+This project contains 5 Eclipse plugins:
 
 * the plugin itself
 * the `plugin.tests` fragment
@@ -14,9 +12,24 @@ This template produces 5 Eclipse plugins:
 The projects can readily be imported inside Eclipse. Additionally, you have maven `pom` files
 based on Tycho, enabling command line builds.
 
-## Building:
+## Note:
 
-This template uses [plugin-profiles](https://github.com/scala-ide/plugin-profiles) to manage the build. Check its documentation for detailed information. The command to use looks like this:
+There are three sets of ready-to-use profiles, for different flavors of Scala and Eclipse.
 
-    mvn -Pscala-2.10.x,eclipse-indigo,scala-ide-stable clean install
+* `indigo` (default)
+    * `stable-scala-ide-scala-2.10-indigo` + `scala-2.10` (default)
+    * `stable-scala-ide-scala-2.9-indigo` + `scala-2.9`
+* `juno`
+    * `stable-scala-ide-scala-2.10-juno` + `scala-2.10`
+    * `stable-scala-ide-scala-2.9-juno` + `scala-2.9`
 
+By default, the maven build is performed against the latest stable versions (Scala IDE 3.0
+and Scala 2.10), and it targets Eclipse 3.7 (Indigo).
+
+Run maven like this:
+
+    mvn -P indigo -P stable-scala-ide-scala-2.10-indigo -P scala-2.10 clean install
+
+Or, because the above command uses only default profiles, you can shorten it to:
+
+    mvn clean install

--- a/src/main/g8/pom.xml
+++ b/src/main/g8/pom.xml
@@ -26,4 +26,355 @@
     <module>$pluginName$.update-site</module>
   </modules>
 
+  <properties>
+    <encoding>UTF-8</encoding>
+    <!-- p2 repositories location -->
+    <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
+
+    <!-- fixed versions -->
+    <tycho.version>0.18.1</tycho.version>
+    <scala.plugin.version>3.0.2</scala.plugin.version>
+
+    <!-- tycho test related -->
+    <tycho.test.OSspecific></tycho.test.OSspecific>
+    <!-- Partial workaround against JDT Weaving deadlocks. See #1000317 and the original ticket on https://issuetracker.springsource.com/browse/STS-1445 -->
+    <tycho.test.weaving>-XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass -Dosgi.classloader.lock=classname</tycho.test.weaving>
+    <tycho.test.jvmArgs>-Xmx800m -XX:MaxPermSize=256m -Dsdtcore.headless \${tycho.test.weaving} \${tycho.test.OSspecific}</tycho.test.jvmArgs>
+
+    <!-- dependencies repos -->
+    <eclipse.codename>indigo</eclipse.codename>
+    <repo.eclipse>http://download.eclipse.org/releases/indigo/</repo.eclipse>
+    <repo.ajdt>http://download.eclipse.org/tools/ajdt/37/update</repo.ajdt>
+    <weaving.hook.plugin.version>1.0.200.I20120427-0800</weaving.hook.plugin.version>
+
+    <!-- some default values, can be overwritten by profiles -->
+    <scala.version>2.10.1</scala.version>
+    <version.suffix>2_10</version.suffix>
+    <scala.version.short>2.10</scala.version.short>
+    <version.tag>local</version.tag>
+    <repo.scala-ide>\${repo.scala-ide.root}/sdk/e37/scala210/stable/site</repo.scala-ide>
+    <junit.version>4.10</junit.version>
+   </properties>
+
+  <profiles>
+    <profile>
+      <!-- this is the default profile, building for Scala 2.10 -->
+      <id>scala-2.10</id>
+    </profile>
+    <profile>
+      <!-- Building for Scala 2.9 -->
+      <id>scala-2.9</id>
+      <properties>
+        <scala.version>2.9.3</scala.version>
+        <version.suffix>2_9</version.suffix>
+        <scala.version.short>2.9</scala.version.short>
+      </properties>
+    </profile>
+
+    <profile>
+      <!-- this is the default profile, building for Eclipse 3.7 (Indigo) -->
+      <id>indigo</id>
+    </profile>
+
+    <profile>
+      <!-- this is the default profile, using the stable Scala IDE release -->
+      <!-- stable Scala IDE for Eclipse Indigo with Scala 2.10 -->
+      <id>stable-scala-ide-scala-2.10-indigo</id>
+    </profile>
+    <profile>
+      <!-- stable Scala IDE for Eclipse Indigo with Scala 2.9 -->
+      <id>stable-scala-ide-scala-2.9-indigo</id>
+      <properties>
+        <repo.scala-ide>\${repo.scala-ide.root}/sdk/e37/scala29/stable/site</repo.scala-ide>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>juno</id>
+      <properties>
+        <eclipse.codename>juno</eclipse.codename>
+        <repo.eclipse>http://download.eclipse.org/releases/juno/</repo.eclipse>
+        <repo.ajdt>http://download.eclipse.org/tools/ajdt/42/update</repo.ajdt>
+        <weaving.hook.plugin.version>1.0.200.v20120524-1707</weaving.hook.plugin.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <!-- stable Scala IDE for Eclipse Juno with Scala 2.10 -->
+      <id>stable-scala-ide-scala-2.10-juno</id>
+      <properties>
+         <repo.scala-ide>\${repo.scala-ide.root}/sdk/e38/scala210/stable/site</repo.scala-ide>
+      </properties>
+    </profile>
+    <profile>
+      <!-- stable Scala IDE for Eclipse Juno with Scala 2.9 -->
+      <id>stable-scala-ide-scala-2.9-juno</id>
+      <properties>
+        <repo.scala-ide>\${repo.scala-ide.root}/sdk/e38/scala29/stable/site</repo.scala-ide>
+      </properties>
+    </profile>
+
+    <profile>
+      <!-- some configuration for tests run by tycho on Mac OS -->
+      <id>macOs</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <properties>
+        <tycho.test.OSspecific>-Dosgi.ws=cocoa -XstartOnFirstThread</tycho.test.OSspecific>
+      </properties>
+       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.eclipse.tycho</groupId>
+              <artifactId>tycho-surefire-plugin</artifactId>
+              <configuration>
+                <dependencies>
+                  <dependency>
+                    <artifactId>org.eclipse.jdt.launching.macosx</artifactId>
+                    <type>eclipse-plugin</type>
+                  </dependency>
+                </dependencies>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <!-- This profile should be used when building the plugin for inclusion in the Scala IDE ecosystem. See https://github.com/scala-ide/ecosystem/wiki -->
+      <!-- Using the value of -Drepo.scala-ide, pulls the data needed to set strict version numbers to the manifests for Scala IDE bundles -->
+      <id>set-versions</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.scala-ide</groupId>
+          <artifactId>build-tools_2.9.2</artifactId>
+          <version>0.1.1</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.2.1</version>
+            <executions>
+              <execution>
+                <id>copy.reflect</id>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <classpathScope>compile</classpathScope>
+              <mainClass>org.scalaide.buildtools.UpdateAddonManifests</mainClass>
+              <arguments>
+                <argument>\${repo.scala-ide}</argument>
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <repositories>
+        <repository>
+          <!-- extra repository containing the build package -->
+          <id>typesafe-ide</id>
+          <name>Typesafe IDE repository</name>
+          <url>http://repo.typesafe.com/typesafe/ide-2.9</url>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <!-- scm configuration is require to extract the github hash-->
+  <scm> 
+    <connection>scm:[Git URL to your git repository]</connection>
+    <url>[URL to your project's repository]</url>
+  </scm>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>\${junit.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <repositories>
+    <repository>
+      <id>sonatype.release</id>
+      <name>Sonatype maven release repository</name>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
+      <snapshots><enabled>false</enabled></snapshots>
+    </repository>
+    <repository>
+      <id>sonatype.snapshot</id>
+      <name>Sonatype maven snapshot repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>scala-ide</id>
+      <name>Scala IDE p2 repository</name>
+      <layout>p2</layout>
+      <url>\${repo.scala-ide}</url>
+      <snapshots><enabled>false</enabled></snapshots>
+    </repository>
+    <repository>
+      <id>eclipse.\${eclipse.codename}</id>
+      <name>Eclipse p2 repository</name>
+      <layout>p2</layout>
+      <url>\${repo.eclipse}</url>
+      <snapshots><enabled>false</enabled></snapshots>
+    </repository>
+    <repository>
+      <id>ajdt.\${eclipse.codename}</id>
+      <name>AJDT for Eclipse p2 repository</name>
+      <layout>p2</layout>
+      <url>\${repo.ajdt}</url>
+      <snapshots><enabled>false</enabled></snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-surefire-plugin</artifactId>
+          <version>\${tycho.version}</version>
+          <configuration>
+            <useUIHarness>false</useUIHarness>
+            <useUIThread>false</useUIThread>
+  
+            <!-- Enable JDT weaving -->
+            <systemProperties combine.children="append">
+              <aj.weaving.verbose>true</aj.weaving.verbose>
+              <org.aspectj.weaver.showWeaveInfo>true</org.aspectj.weaver.showWeaveInfo>
+              <org.aspectj.osgi.verbose>true</org.aspectj.osgi.verbose>
+            </systemProperties>
+            <frameworkExtensions>
+              <frameworkExtension>
+                <groupId>p2.osgi.bundle</groupId>
+                <artifactId>org.eclipse.equinox.weaving.hook</artifactId>
+                <version>\${weaving.hook.plugin.version}</version>
+              </frameworkExtension>
+            </frameworkExtensions>
+            <bundleStartLevel>
+              <bundle>
+                <id>org.eclipse.equinox.weaving.aspectj</id>
+                <level>2</level>
+                <autoStart>true</autoStart>
+              </bundle>
+            </bundleStartLevel>
+            <argLine>\${tycho.test.jvmArgs}</argLine>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>\${tycho.version}</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-compiler-plugin</artifactId>
+        <version>\${tycho.version}</version>
+        <configuration>
+          <excludeResources>
+            <excludeResource>**/*.scala</excludeResource>
+          </excludeResources>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- configuration of the scala compiler -->
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>\${scala.plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <jvmArgs>
+            <jvmArg>-Xms512m</jvmArg>
+            <jvmArg>-Xmx1024m</jvmArg>
+          </jvmArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-source-plugin</artifactId>
+        <version>\${tycho.version}</version>
+        <executions>
+          <execution>
+            <id>attach-source</id>
+            <goals>
+              <goal>plugin-source</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- for setting a better qualifier -->
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <version>\${tycho.version}</version>
+        <configuration>
+          <format>'\${version.tag}-\${version.suffix}-'yyyyMMddHHmm'-\${buildNumber}'</format>
+          <archiveSite>true</archiveSite>
+        </configuration>
+      </plugin>
+      <!-- plugin used to extract the git hash-->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <doCheck>false</doCheck>
+          <doUpdate>false</doUpdate>
+          <shortRevisionLength>7</shortRevisionLength>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
- Updated project's README and explained how to create a Scala IDE plug-in in
  3 simple steps.
- Updated POM used by the generated plug-in
  - Use Tycho 0.16
  - Parametrized indigo and juno builds
  - Updated build profiles for next Scala IDE v3.0 release
  - Added profile for setting strict bundle versions (needed before building
    plug-in for inclusion in the ecosystem)
- Update REAMDE of the generated plug-in to reflect changes in the POM's
  profile

Closes #2. Review by @dotta.
